### PR TITLE
add row & column screen

### DIFF
--- a/Flutter/flutter_gallery_app/lib/src/core/config/app_router.dart
+++ b/Flutter/flutter_gallery_app/lib/src/core/config/app_router.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_gallery_app/src/presentation/home/screen/home_page.dart';
+import 'package:flutter_gallery_app/src/presentation/row_column/screen/row_column_page.dart';
 import 'package:flutter_gallery_app/src/presentation/typography/screen/typography_page.dart';
 
 part 'app_router.gr.dart';
@@ -10,5 +11,6 @@ class AppRouter extends _$AppRouter {
   List<AutoRoute> get routes => [
         AutoRoute(page: HomeRoute.page, initial: true),
         AutoRoute(path: '/typography', page: TypographyRoute.page),
+        AutoRoute(path: '/rowColumn', page: RowColumnRoute.page),
       ];
 }

--- a/Flutter/flutter_gallery_app/lib/src/core/config/app_router.gr.dart
+++ b/Flutter/flutter_gallery_app/lib/src/core/config/app_router.gr.dart
@@ -21,6 +21,12 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const HomePage(),
       );
     },
+    RowColumnRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const RowColumnPage(),
+      );
+    },
     TypographyRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
@@ -40,6 +46,20 @@ class HomeRoute extends PageRouteInfo<void> {
         );
 
   static const String name = 'HomeRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [RowColumnPage]
+class RowColumnRoute extends PageRouteInfo<void> {
+  const RowColumnRoute({List<PageRouteInfo>? children})
+      : super(
+          RowColumnRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'RowColumnRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
 }

--- a/Flutter/flutter_gallery_app/lib/src/core/constants/list_gallery_item.dart
+++ b/Flutter/flutter_gallery_app/lib/src/core/constants/list_gallery_item.dart
@@ -57,7 +57,7 @@ final List<GalleryItem> galleryItems = [
     title: 'Row & Column',
     subTitle:
         'A widget that displays its children in a horizontal and vertical array',
-    router: '/',
+    router: '/rowColumn',
   ),
   GalleryItem(
     icon: Icons.edit_attributes_rounded,

--- a/Flutter/flutter_gallery_app/lib/src/presentation/row_column/bloc/row_column_bloc.dart
+++ b/Flutter/flutter_gallery_app/lib/src/presentation/row_column/bloc/row_column_bloc.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gallery_app/src/presentation/row_column/bloc/row_column_event.dart';
+import 'package:flutter_gallery_app/src/presentation/row_column/bloc/row_column_state.dart';
+
+class RowColumnBloc extends Bloc<RowColumnEvent, RowColumnState> {
+  RowColumnBloc() : super(InitState()) {
+    on<ChangeViewEvent>((event, emit) => emit(ChangeViewState()));
+  }
+}

--- a/Flutter/flutter_gallery_app/lib/src/presentation/row_column/bloc/row_column_event.dart
+++ b/Flutter/flutter_gallery_app/lib/src/presentation/row_column/bloc/row_column_event.dart
@@ -1,0 +1,8 @@
+import 'package:equatable/equatable.dart';
+
+abstract class RowColumnEvent extends Equatable {}
+
+class ChangeViewEvent extends RowColumnEvent {
+  @override
+  List<Object?> get props => [identityHashCode(this)];
+}

--- a/Flutter/flutter_gallery_app/lib/src/presentation/row_column/bloc/row_column_state.dart
+++ b/Flutter/flutter_gallery_app/lib/src/presentation/row_column/bloc/row_column_state.dart
@@ -1,0 +1,13 @@
+import 'package:equatable/equatable.dart';
+
+abstract class RowColumnState extends Equatable {}
+
+class InitState extends RowColumnState {
+  @override
+  List<Object?> get props => [identityHashCode(this)];
+}
+
+class ChangeViewState extends RowColumnState {
+  @override
+  List<Object?> get props => [identityHashCode(this)];
+}

--- a/Flutter/flutter_gallery_app/lib/src/presentation/row_column/screen/row_column_page.dart
+++ b/Flutter/flutter_gallery_app/lib/src/presentation/row_column/screen/row_column_page.dart
@@ -1,0 +1,213 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gallery_app/src/presentation/row_column/bloc/row_column_bloc.dart';
+import 'package:flutter_gallery_app/src/presentation/row_column/bloc/row_column_event.dart';
+import 'package:flutter_gallery_app/src/presentation/row_column/bloc/row_column_state.dart';
+import 'package:flutter_gallery_app/src/presentation/row_column/widgets/view_option_dropdown.dart';
+
+@RoutePage()
+class RowColumnPage extends StatelessWidget {
+  const RowColumnPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<RowColumnBloc>(
+      create: (_) => RowColumnBloc(),
+      child: const RowColumnView(),
+    );
+  }
+}
+
+class RowColumnView extends StatefulWidget {
+  const RowColumnView({super.key});
+
+  @override
+  State<RowColumnView> createState() => _RowColumnViewState();
+}
+
+class _RowColumnViewState extends State<RowColumnView> {
+  final List<Widget> icons = [
+    const Icon(Icons.brightness_auto),
+    const Icon(Icons.brightness_auto, size: 50),
+    const Icon(Icons.brightness_auto)
+  ];
+
+  final List<MainAxisAlignment> listMainAxisAlignment = [
+    MainAxisAlignment.center,
+    MainAxisAlignment.end,
+    MainAxisAlignment.spaceAround,
+    MainAxisAlignment.spaceBetween,
+    MainAxisAlignment.spaceEvenly,
+    MainAxisAlignment.start,
+  ];
+
+  final List<CrossAxisAlignment> listCrossAxisAlignment = [
+    CrossAxisAlignment.center,
+    CrossAxisAlignment.end,
+    CrossAxisAlignment.baseline,
+    CrossAxisAlignment.stretch,
+    CrossAxisAlignment.start,
+  ];
+
+  bool isRow = true;
+
+  MainAxisSize mainAxisSize = MainAxisSize.min;
+
+  MainAxisAlignment mainAxisAlignment = MainAxisAlignment.center;
+
+  CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.center;
+
+  VerticalDirection verticalDirection = VerticalDirection.up;
+
+  TextDirection textDirection = TextDirection.ltr;
+
+  TextBaseline textBaseline = TextBaseline.alphabetic;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("Row & Column")),
+      bottomNavigationBar: viewOption(),
+      body: mainView(),
+    );
+  }
+
+  Widget mainView() {
+    return BlocBuilder<RowColumnBloc, RowColumnState>(
+      builder: (context, state) {
+        return SafeArea(
+          child: Container(
+            color: Colors.yellow,
+            child: isRow
+                ? Row(
+                    mainAxisAlignment: mainAxisAlignment,
+                    crossAxisAlignment: crossAxisAlignment,
+                    textBaseline: textBaseline,
+                    textDirection: textDirection,
+                    verticalDirection: verticalDirection,
+                    children: icons,
+                  )
+                : Column(
+                    mainAxisAlignment: mainAxisAlignment,
+                    crossAxisAlignment: crossAxisAlignment,
+                    textBaseline: textBaseline,
+                    textDirection: textDirection,
+                    verticalDirection: verticalDirection,
+                    children: icons,
+                  ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget viewOption() {
+    return BlocBuilder<RowColumnBloc, RowColumnState>(
+      builder: (context, state) {
+        return Material(
+          elevation: 10,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                pickViewType(),
+                ViewOptionDropdown(
+                  value: mainAxisSize,
+                  title: "mainAxisSize",
+                  items: const [MainAxisSize.max, MainAxisSize.min],
+                  onChanged: (state) {
+                    mainAxisSize = state!;
+                    context.read<RowColumnBloc>().add(ChangeViewEvent());
+                  },
+                ),
+                ViewOptionDropdown(
+                  value: mainAxisAlignment,
+                  title: "mainAxisAlignment",
+                  items: listMainAxisAlignment,
+                  onChanged: (state) {
+                    mainAxisAlignment = state!;
+                    context.read<RowColumnBloc>().add(ChangeViewEvent());
+                  },
+                ),
+                ViewOptionDropdown(
+                  value: crossAxisAlignment,
+                  title: "crossAxisAlignment",
+                  items: listCrossAxisAlignment,
+                  onChanged: (state) {
+                    crossAxisAlignment = state!;
+                    context.read<RowColumnBloc>().add(ChangeViewEvent());
+                  },
+                ),
+                ViewOptionDropdown(
+                  value: verticalDirection,
+                  title: "verticalDirection",
+                  items: const [VerticalDirection.down, VerticalDirection.up],
+                  onChanged: (state) {
+                    verticalDirection = state!;
+                    context.read<RowColumnBloc>().add(ChangeViewEvent());
+                  },
+                ),
+                ViewOptionDropdown(
+                  value: textDirection,
+                  title: "textDirection",
+                  items: const [TextDirection.ltr, TextDirection.rtl],
+                  onChanged: (state) {
+                    textDirection = state!;
+                    context.read<RowColumnBloc>().add(ChangeViewEvent());
+                  },
+                ),
+                ViewOptionDropdown(
+                  value: textBaseline,
+                  title: "textBaseline",
+                  items: const [
+                    TextBaseline.alphabetic,
+                    TextBaseline.ideographic,
+                  ],
+                  onChanged: (state) {
+                    textBaseline = state!;
+                    context.read<RowColumnBloc>().add(ChangeViewEvent());
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget pickViewType() {
+    return BlocBuilder<RowColumnBloc, RowColumnState>(
+      builder: (context, state) {
+        return Row(
+          children: [
+            Expanded(
+              child: RadioListTile(
+                value: true,
+                groupValue: isRow,
+                onChanged: (value) {
+                  isRow = value!;
+                  context.read<RowColumnBloc>().add(ChangeViewEvent());
+                },
+                title: const Text("Row"),
+              ),
+            ),
+            Expanded(
+              child: RadioListTile(
+                value: false,
+                groupValue: isRow,
+                onChanged: (value) {
+                  isRow = value!;
+                  context.read<RowColumnBloc>().add(ChangeViewEvent());
+                },
+                title: const Text("Column"),
+              ),
+            )
+          ],
+        );
+      },
+    );
+  }
+}

--- a/Flutter/flutter_gallery_app/lib/src/presentation/row_column/widgets/view_option_dropdown.dart
+++ b/Flutter/flutter_gallery_app/lib/src/presentation/row_column/widgets/view_option_dropdown.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class ViewOptionDropdown<T> extends StatelessWidget {
+  const ViewOptionDropdown({
+    super.key,
+    required this.title,
+    required this.value,
+    required this.items,
+    required this.onChanged,
+  });
+
+  final String title;
+  final Function(T? state) onChanged;
+  final List<T> items;
+  final T value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(title),
+        DropdownButton<T>(
+          icon: const Icon(Icons.keyboard_arrow_down_rounded),
+          value: value,
+          items: items
+              .map((e) => DropdownMenuItem<T>(
+                    value: e,
+                    child: Text(e.toString().split(".").last),
+                  ))
+              .toList(),
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}

--- a/Flutter/flutter_gallery_app/pubspec.lock
+++ b/Flutter/flutter_gallery_app/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.3.1"
+  bloc:
+    dependency: transitive
+    description:
+      name: bloc
+      sha256: "3820f15f502372d979121de1f6b97bfcf1630ebff8fe1d52fb2b0bfa49be5b49"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -193,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:
@@ -222,6 +238,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_bloc:
+    dependency: "direct main"
+    description:
+      name: flutter_bloc
+      sha256: e74efb89ee6945bcbce74a5b3a5a3376b088e5f21f55c263fc38cbdc6237faae
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.3"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -347,6 +371,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
@@ -379,6 +411,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.5"
   pub_semver:
     dependency: transitive
     description:

--- a/Flutter/flutter_gallery_app/pubspec.yaml
+++ b/Flutter/flutter_gallery_app/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   auto_route: ^7.8.3
+  flutter_bloc: ^8.1.3
+  equatable: ^2.0.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Description Pull Request:
## Todo
- Create new row & column page Flutter Gallery App
## Task
Link of task: https://www.notion.so/dustin0306/Row-Column-Expanded-a6794bc43cc64c2d89f9ec8fac98f8fc?pvs=4
## Screenshot
![image](https://github.com/krish-do-goldenowl/walter-theory-trainings/assets/144195318/fcee6b3c-1268-486b-b18b-b6024cfad8b1)
![image](https://github.com/krish-do-goldenowl/walter-theory-trainings/assets/144195318/c5ea0068-9fb5-47b6-a30a-c99733b9f6ca)

##Videos

https://github.com/krish-do-goldenowl/walter-theory-trainings/assets/144195318/3fbaed3c-f058-4f40-a535-4b0dff3b51d6


